### PR TITLE
Typo in `npm run test`

### DIFF
--- a/exercises/3-revenge-of-the-automated-testing/README.md
+++ b/exercises/3-revenge-of-the-automated-testing/README.md
@@ -369,7 +369,7 @@ git push -u origin feature/important-flag
 
 3. Let's get our tests running by executing a `--watch` on our tests. This will keep re-running our tests everytime there is a file change. It is handy to have this running in a new terminal session.
 ```bash
-npm run test -- --watch
+npm run test --watch
 ```
 
 3. All the tests should be passing when we begin. If `No tests found related to files changed since last commit` is on show; hit `a` on the terminal to re-run `all` tests.


### PR DESCRIPTION
This is a typo, because result of this command is following:
```
> todolist-fe@1.0.0 test /home/lmaly/innovation-labs/todolist-fe
> vue-cli-service test "--watch"

Error: watch /home/lmaly/innovation-labs/todolist-fe ENOSPC
    at exports._errnoException (util.js:1026:11)
    at FSWatcher.start (fs.js:1371:19)
    at Object.fs.watch (fs.js:1397:11)
    at NodeWatcher.watchdir (/home/lmaly/innovation-labs/todolist-fe/node_modules/sane/src/node_watcher.js:175:20)
    at new NodeWatcher (/home/lmaly/innovation-labs/todolist-fe/node_modules/sane/src/node_watcher.js:45:8)
    at createWatcher (/home/lmaly/innovation-labs/todolist-fe/node_modules/jest-haste-map/build/index.js:572:23)
    at Array.map (native)
    at HasteMap._watch (/home/lmaly/innovation-labs/todolist-fe/node_modules/jest-haste-map/build/index.js:683:44)
    at _buildPromise._buildFileMap.then.then.hasteMap (/home/lmaly/innovation-labs/todolist-fe/node_modules/jest-haste-map/build/index.js:280:21)
    at <anonymous>
 ERROR  jest exited with code 1.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! todolist-fe@1.0.0 test: `vue-cli-service test "--watch"`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the todolist-fe@1.0.0 test script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/lmaly/.npm/_logs/2018-10-18T03_58_31_443Z-debug.log
```

The correct command is without `--` as per this PR.